### PR TITLE
Run "npm ci" instead of "npm install" in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ ENTRYPOINT ["gunicorn", "-b", "0.0.0.0:5000", "trommelkreis.wsgi"]
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r ./requirements.txt
 
-COPY --chown=pn package.json package-lock.json ./
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
 
 
 ################################################################################


### PR DESCRIPTION
This results in deterministic builds using package-lock.json. It also
doesn't try to modify package-lock.json so we can leave out the "chown"
part.