### PR TITLE
Fix URL returned by API for audio files

### DIFF
--- a/archive/schema.py
+++ b/archive/schema.py
@@ -30,7 +30,7 @@ class AudioFileType(DjangoObjectType):
     artist = graphene.String()
 
     def resolve_url(parent, info):
-        return f"{base_link}{parent.url}"
+        return parent.url
 
     def resolve_duration(parent, info):
         # TODO: this is defined multiple times now. refactor as model property!


### PR DESCRIPTION
Previous behaviour:
`https://trommelkreis.club/https://<link_to_bucket>`

Fixed behaviour:
`https://<link_to_bucket>`
