### PR TITLE
Two bugfixes

### DIFF
--- a/archive/MP3Field.py
+++ b/archive/MP3Field.py
@@ -19,10 +19,10 @@ class MP3File(File):
         return self._duration_cache
 
     def _calculate_duration(self):
-        from mutagen.mp3 import EasyMP3
-
-        mp3 = EasyMP3(self)
-        return round(mp3.info.length)
+        # Quick and dirty fix as we no longer support looking up duration on the server side.
+        # At some point it might be nice to store this in the db.
+        # See https://github.com/fshstk/trommelkreis/issues/103
+        return 0
 
 
 class MP3FileDescriptor(FileDescriptor):

--- a/archive/models.py
+++ b/archive/models.py
@@ -156,7 +156,11 @@ class AudioFile(SlugIncluded):
         if self.artist:
             mp3["artist"] = self.artist.name
         mp3["album"] = f"Digitaler Trommelkreis | {self.session.slug}"
+
+        tempfile.seek(0) # May cause issues if not done before saving mp3
         mp3.save(tempfile)
 
         self.data.storage.delete(self.data.name)
+
+        tempfile.seek(0) # May cause issues if not done before saving mp3
         self.data.save(os.path.basename(self.data.name), tempfile, save=False)


### PR DESCRIPTION
1. Properly seek uploaded file to start to prevent duplicate ID3 tags (which in turn causes the discord bot to refuse to play the file)
2. Don't calculate duration by directly reading the file for 1k+ mp3s because that's insane.